### PR TITLE
fix: prioritize active pod state in image pull health scoring

### DIFF
--- a/app/collectors/kubernetes_collector.py
+++ b/app/collectors/kubernetes_collector.py
@@ -61,20 +61,79 @@ class KubernetesCollector:
             raise KubernetesCollectorError(f"Failed to list Kubernetes pods: {exc}") from exc
 
     def collect_image_pull_health(self, window_minutes: int = 15) -> dict[str, Any]:
+        """
+        Backward-compatible image pull health collector.
+
+        Keeps the existing component contract (`image_pull_health`) but fixes the logic by:
+        - using active pod/container waiting state as primary truth
+        - using recent Kubernetes events as supporting evidence
+        """
         cutoff = datetime.now(timezone.utc) - timedelta(minutes=window_minutes)
+
+        pods = []
         events = []
 
         if self.namespaces:
             for namespace in self.namespaces:
+                pods.extend(self._list_pods(namespace=namespace))
                 events.extend(self._list_events(namespace=namespace))
         else:
+            pods = self._list_pods()
             events = self._list_events()
 
-        pull_failures = 0
-        affected_registries: set[str] = set()
+        active_failure_reasons = {"ErrImagePull", "ImagePullBackOff", "InvalidImageName"}
 
+        active_pull_failures = 0
+        recent_pull_failure_events = 0
+        affected_registries: set[str] = set()
+        affected_pods: set[str] = set()
+
+        def extract_registry(image: str) -> str:
+            if not image:
+                return "unknown"
+            return image.split("/")[0] if "/" in image else "docker.io"
+
+        # Primary truth: active pod/container waiting state
+        for pod in pods:
+            metadata = getattr(pod, "metadata", None)
+            status = getattr(pod, "status", None)
+
+            if metadata is None or status is None:
+                continue
+
+            namespace = getattr(metadata, "namespace", "unknown")
+            pod_name = getattr(metadata, "name", "unknown")
+
+            container_statuses = getattr(status, "container_statuses", None) or []
+            init_container_statuses = getattr(status, "init_container_statuses", None) or []
+            all_statuses = list(init_container_statuses) + list(container_statuses)
+
+            pod_has_active_failure = False
+
+            for container_status in all_statuses:
+                state = getattr(container_status, "state", None)
+                waiting = getattr(state, "waiting", None) if state else None
+                if waiting is None:
+                    continue
+
+                reason = getattr(waiting, "reason", "") or ""
+                image = getattr(container_status, "image", "") or ""
+
+                if reason in active_failure_reasons:
+                    pod_has_active_failure = True
+                    affected_registries.add(extract_registry(image))
+
+            if pod_has_active_failure:
+                active_pull_failures += 1
+                affected_pods.add(f"{namespace}/{pod_name}")
+
+        # Supporting evidence: recent events
         for event in events:
-            event_time = getattr(event, "last_timestamp", None) or getattr(event, "event_time", None)
+            event_time = (
+                    getattr(event, "last_timestamp", None)
+                    or getattr(event, "event_time", None)
+                    or getattr(event, "first_timestamp", None)
+            )
             if event_time is None:
                 continue
 
@@ -88,31 +147,102 @@ class KubernetesCollector:
             message = getattr(event, "message", "") or ""
 
             if (
-                "ErrImagePull" in reason
-                or "ImagePullBackOff" in reason
-                or "Failed to pull image" in message
-                or "Error: ErrImagePull" in message
+                    "ErrImagePull" in message
+                    or "ImagePullBackOff" in message
+                    or "Failed to pull image" in message
+                    or "Back-off pulling image" in message
+                    or "Error: ErrImagePull" in message
+                    or (reason == "BackOff" and "pull" in message.lower())
+                    or (reason == "Failed" and "image" in message.lower())
             ):
-                pull_failures += 1
+                recent_pull_failure_events += 1
+
+                involved_object = getattr(event, "involved_object", None)
+                namespace = getattr(involved_object, "namespace", "unknown") if involved_object else "unknown"
+                pod_name = getattr(involved_object, "name", "unknown") if involved_object else "unknown"
+
+                if pod_name != "unknown":
+                    affected_pods.add(f"{namespace}/{pod_name}")
 
                 match = re.search(r'image "([^"]+)"', message)
                 if match:
                     image = match.group(1)
-                    registry = image.split("/")[0] if "/" in image else "docker.io"
-                    affected_registries.add(registry)
+                    affected_registries.add(extract_registry(image))
 
+        # Backward compatibility:
+        # keep pull_failures_15m for existing scorer/raw payload expectations
         result = {
-            "pull_failures_15m": pull_failures,
+            "pull_failures_15m": recent_pull_failure_events,
+            "active_pull_failures": active_pull_failures,
+            "recent_pull_failure_events": recent_pull_failure_events,
+            "affected_pods": sorted(affected_pods),
             "affected_registries": sorted(affected_registries),
+            "window_minutes": window_minutes,
         }
 
         logger.info(
-            "Collected image pull health pull_failures_15m=%d affected_registries=%s",
-            result["pull_failures_15m"],
+            "Collected image pull health active_pull_failures=%d recent_pull_failure_events=%d affected_pods=%s affected_registries=%s",
+            result["active_pull_failures"],
+            result["recent_pull_failure_events"],
+            result["affected_pods"],
             result["affected_registries"],
         )
 
         return result
+
+    # def collect_image_pull_health(self, window_minutes: int = 15) -> dict[str, Any]:
+    #     cutoff = datetime.now(timezone.utc) - timedelta(minutes=window_minutes)
+    #     events = []
+    #
+    #     if self.namespaces:
+    #         for namespace in self.namespaces:
+    #             events.extend(self._list_events(namespace=namespace))
+    #     else:
+    #         events = self._list_events()
+    #
+    #     pull_failures = 0
+    #     affected_registries: set[str] = set()
+    #
+    #     for event in events:
+    #         event_time = getattr(event, "last_timestamp", None) or getattr(event, "event_time", None)
+    #         if event_time is None:
+    #             continue
+    #
+    #         if event_time.tzinfo is None:
+    #             event_time = event_time.replace(tzinfo=timezone.utc)
+    #
+    #         if event_time < cutoff:
+    #             continue
+    #
+    #         reason = getattr(event, "reason", "") or ""
+    #         message = getattr(event, "message", "") or ""
+    #
+    #         if (
+    #             "ErrImagePull" in reason
+    #             or "ImagePullBackOff" in reason
+    #             or "Failed to pull image" in message
+    #             or "Error: ErrImagePull" in message
+    #         ):
+    #             pull_failures += 1
+    #
+    #             match = re.search(r'image "([^"]+)"', message)
+    #             if match:
+    #                 image = match.group(1)
+    #                 registry = image.split("/")[0] if "/" in image else "docker.io"
+    #                 affected_registries.add(registry)
+    #
+    #     result = {
+    #         "pull_failures_15m": pull_failures,
+    #         "affected_registries": sorted(affected_registries),
+    #     }
+    #
+    #     logger.info(
+    #         "Collected image pull health pull_failures_15m=%d affected_registries=%s",
+    #         result["pull_failures_15m"],
+    #         result["affected_registries"],
+    #     )
+    #
+    #     return result
 
     def collect_startup_latency(self, window_minutes: int = 30) -> dict[str, Any]:
         cutoff = datetime.now(timezone.utc) - timedelta(minutes=window_minutes)

--- a/app/scoring/normalization.py
+++ b/app/scoring/normalization.py
@@ -49,32 +49,79 @@ def score_restart_pressure(*, recent_restarts_15m: int) -> tuple[float, str, dic
     }
     return score, reason, raw
 
-
 def score_image_pull_health(
     *,
     pull_failures_15m: int,
+    active_pull_failures: int = 0,
+    recent_pull_failure_events: int | None = None,
+    affected_pods: list[str] | None = None,
     affected_registries: list[str] | None = None,
+    window_minutes: int = 15,
 ) -> tuple[float, str, dict]:
+    affected_pods = affected_pods or []
     affected_registries = affected_registries or []
+    recent_pull_failure_events = (
+        pull_failures_15m if recent_pull_failure_events is None else recent_pull_failure_events
+    )
 
-    if pull_failures_15m == 0:
+    # Active blocker takes priority
+    if active_pull_failures > 0:
+        if active_pull_failures == 1:
+            score = 0.0
+            reason = "Active image pull failure is currently blocking rollout confidence."
+        else:
+            score = 0.0
+            reason = "Multiple active image pull failures are currently blocking rollout confidence."
+
+    # Recent instability is softer than active failure
+    elif recent_pull_failure_events == 0:
         score = 100.0
-        reason = "No recent image pull failures detected."
-    elif pull_failures_15m == 1:
+        reason = "No active or recent image pull failures detected."
+    elif recent_pull_failure_events == 1:
         score = 75.0
         reason = "A recent image pull failure slightly reduced rollout confidence."
-    elif pull_failures_15m <= 3:
+    elif recent_pull_failure_events <= 3:
         score = 45.0
         reason = "Recent image pull failures reduced rollout confidence."
     else:
         score = 15.0
-        reason = "Repeated image pull failures present a major rollout risk."
+        reason = "Repeated recent image pull failures indicate major rollout risk."
 
     raw = {
         "pull_failures_15m": pull_failures_15m,
+        "active_pull_failures": active_pull_failures,
+        "recent_pull_failure_events": recent_pull_failure_events,
+        "affected_pods": affected_pods,
         "affected_registries": affected_registries,
+        "window_minutes": window_minutes,
     }
     return score, reason, raw
+
+# def score_image_pull_health(
+#     *,
+#     pull_failures_15m: int,
+#     affected_registries: list[str] | None = None,
+# ) -> tuple[float, str, dict]:
+#     affected_registries = affected_registries or []
+#
+#     if pull_failures_15m == 0:
+#         score = 100.0
+#         reason = "No recent image pull failures detected."
+#     elif pull_failures_15m == 1:
+#         score = 75.0
+#         reason = "A recent image pull failure slightly reduced rollout confidence."
+#     elif pull_failures_15m <= 3:
+#         score = 45.0
+#         reason = "Recent image pull failures reduced rollout confidence."
+#     else:
+#         score = 15.0
+#         reason = "Repeated image pull failures present a major rollout risk."
+#
+#     raw = {
+#         "pull_failures_15m": pull_failures_15m,
+#         "affected_registries": affected_registries,
+#     }
+#     return score, reason, raw
 
 
 def score_startup_latency(*, p95_startup_seconds: float) -> tuple[float, str, dict]:


### PR DESCRIPTION
## Summary
This PR fixes `image_pull_health` scoring by using active pod/container waiting state as the primary signal and recent Kubernetes events as supporting evidence.

## Problem
Previously, `image_pull_health` relied mainly on recent Kubernetes events in a time window.
This could allow the component to recover to healthy while workloads were still in active `ErrImagePull` or `ImagePullBackOff`.

## Changes
- kept the existing `image_pull_health` component name and external contract
- updated the Kubernetes collector to inspect active pod/container waiting state
- retained recent Kubernetes event history as supporting instability evidence
- updated image pull scoring so active failures take priority over recent event-only signals
- preserved backward compatibility for dashboards, API responses, and persisted component naming

## Why this matters
Deploy Confidence should not report healthy image pull status while active image pull failures are still present.
This change reduces false green recovery without introducing broader scoring model or schema changes.

## Validation
- simulated an invalid image tag in a controlled namespace
- observed active `ErrImagePull` / `ImagePullBackOff` behavior
- verified that active image pull failures remain degraded instead of recovering prematurely
- confirmed recent event history still contributes as supporting rollout-risk evidence

## Notes
This PR intentionally keeps the current `image_pull_health` component name to minimize blast radius in the running Kubernetes environment.
A future follow-up can split blocker vs instability semantics into separate components if needed.