### PR TITLE
fix: calculate startup latency from pod readiness transition

### DIFF
--- a/app/collectors/kubernetes_collector.py
+++ b/app/collectors/kubernetes_collector.py
@@ -264,20 +264,33 @@ class KubernetesCollector:
                 continue
 
             created_at = getattr(metadata, "creation_timestamp", None)
-            started_at = getattr(status, "start_time", None)
-
-            if created_at is None or started_at is None:
+            if created_at is None:
                 continue
 
             if created_at.tzinfo is None:
                 created_at = created_at.replace(tzinfo=timezone.utc)
-            if started_at.tzinfo is None:
-                started_at = started_at.replace(tzinfo=timezone.utc)
 
             if created_at < cutoff:
                 continue
 
-            duration_seconds = (started_at - created_at).total_seconds()
+            ready_at = None
+            conditions = getattr(status, "conditions", None) or []
+
+            for condition in conditions:
+                condition_type = getattr(condition, "type", None)
+                condition_status = getattr(condition, "status", None)
+
+                if condition_type == "Ready" and condition_status == "True":
+                    ready_at = getattr(condition, "last_transition_time", None)
+                    break
+
+            if ready_at is None:
+                continue
+
+            if ready_at.tzinfo is None:
+                ready_at = ready_at.replace(tzinfo=timezone.utc)
+
+            duration_seconds = (ready_at - created_at).total_seconds()
             if duration_seconds < 0:
                 continue
 
@@ -300,6 +313,63 @@ class KubernetesCollector:
         )
 
         return result
+
+    # def collect_startup_latency(self, window_minutes: int = 30) -> dict[str, Any]:
+    #     cutoff = datetime.now(timezone.utc) - timedelta(minutes=window_minutes)
+    #     pods = []
+    #
+    #     if self.namespaces:
+    #         for namespace in self.namespaces:
+    #             pods.extend(self._list_pods(namespace=namespace))
+    #     else:
+    #         pods = self._list_pods()
+    #
+    #     startup_durations: list[float] = []
+    #
+    #     for pod in pods:
+    #         metadata = getattr(pod, "metadata", None)
+    #         status = getattr(pod, "status", None)
+    #
+    #         if metadata is None or status is None:
+    #             continue
+    #
+    #         created_at = getattr(metadata, "creation_timestamp", None)
+    #         started_at = getattr(status, "start_time", None)
+    #
+    #         if created_at is None or started_at is None:
+    #             continue
+    #
+    #         if created_at.tzinfo is None:
+    #             created_at = created_at.replace(tzinfo=timezone.utc)
+    #         if started_at.tzinfo is None:
+    #             started_at = started_at.replace(tzinfo=timezone.utc)
+    #
+    #         if created_at < cutoff:
+    #             continue
+    #
+    #         duration_seconds = (started_at - created_at).total_seconds()
+    #         if duration_seconds < 0:
+    #             continue
+    #
+    #         startup_durations.append(duration_seconds)
+    #
+    #     if not startup_durations:
+    #         p95 = 0.0
+    #     elif len(startup_durations) == 1:
+    #         p95 = float(startup_durations[0])
+    #     else:
+    #         p95 = float(quantiles(startup_durations, n=100, method="inclusive")[94])
+    #
+    #     result = {
+    #         "p95_startup_seconds": round(p95, 2),
+    #     }
+    #
+    #     logger.info(
+    #         "Collected startup latency p95_startup_seconds=%.2f",
+    #         result["p95_startup_seconds"],
+    #     )
+    #
+    #     return result
 
     def collect_kubernetes_inputs(self) -> dict[str, dict[str, Any]]:
         return {


### PR DESCRIPTION
## Summary

This PR fixes startup latency calculation in the Kubernetes collector.

Previously, startup latency was calculated from:

- `metadata.creation_timestamp`
- to `status.start_time`

That measured pod start timing, but not when the workload actually became ready to serve traffic.

This PR updates the collector to calculate startup latency from:

- `metadata.creation_timestamp`
- to the pod `Ready=True` condition `last_transition_time`

## Why

For deploy confidence scoring, readiness is a better signal than pod start time.

A pod can be started but still not be ready for traffic. Using the readiness transition gives a more accurate representation of rollout usability and startup behavior.

## Scope of change

This change is limited to:

- `app/collectors/kubernetes_collector.py`
- `collect_startup_latency()`

## What changed

Replaced the previous calculation:

- `status.start_time - metadata.creation_timestamp`

with:

- `Ready=True last_transition_time - metadata.creation_timestamp`

## Impact

- improves accuracy of `p95_startup_seconds`
- keeps the existing output contract unchanged
- does not require PostgreSQL schema changes
- does not change scoring interfaces or API payload shape

## Out of scope

- threshold tuning
- scoring refactor
- node headroom fixes
- schema changes
- broader collector redesign

## Validation

After deployment:
- verify the pod remains healthy
- verify `/live` and `/ready` continue to return 200
- verify `startup_latency` values reflect readiness timing more realistically
- verify dashboard startup latency behavior improves