### PR TITLE
fix: scope startup latency to deploy-confidence-service pods

### DIFF
--- a/app/collectors/kubernetes_collector.py
+++ b/app/collectors/kubernetes_collector.py
@@ -263,6 +263,10 @@ class KubernetesCollector:
             if metadata is None or status is None:
                 continue
 
+            labels = getattr(metadata, "labels", {}) or {}
+            if labels.get("app") != "deploy-confidence-service":
+                continue
+
             created_at = getattr(metadata, "creation_timestamp", None)
             if created_at is None:
                 continue


### PR DESCRIPTION
## Summary

This PR scopes startup latency calculation to the deploy-confidence-service application pods only.

The previous startup latency fix corrected the timestamp source by using the pod `Ready=True` transition time. However, the collector was still aggregating over a pod set that was too broad, which allowed unrelated or stale pod startup samples to skew `p95_startup_seconds`.

This change narrows the calculation to pods labeled:

- `app=deploy-confidence-service`

## Why

For deploy-confidence scoring, startup latency should reflect the readiness behavior of the relevant application only.

Without this filter, unrelated pods can inflate startup latency and produce misleading startup-risk signals.

## Scope of change

This change is limited to:

- `app/collectors/kubernetes_collector.py`
- `collect_startup_latency()`

## What changed

Added label-based filtering so only pods with:

- `app=deploy-confidence-service`

are included in startup latency calculation.

The calculation continues to use:

- `creation_timestamp`
- to pod `Ready=True` condition `last_transition_time`

## Impact

- reduces startup latency noise from unrelated pods
- improves accuracy of `p95_startup_seconds` for deploy-confidence evaluation
- keeps the existing output contract unchanged
- does not require PostgreSQL schema changes
- does not change scoring interfaces or API payload shape

## Out of scope

- threshold tuning
- scoring refactor
- node headroom fixes
- database schema changes
- broader collector redesign
- making app label filtering configurable

## Validation

After deployment:
- verify the pod remains healthy
- verify `/live` and `/ready` continue to return 200
- verify `startup_latency` values are no longer skewed by unrelated pods
- verify dashboard startup latency behavior reflects deploy-confidence-service pods only

Closes #5 