### PR TITLE
fix: handle empty startup latency samples conservatively

### DIFF
--- a/app/collectors/kubernetes_collector.py
+++ b/app/collectors/kubernetes_collector.py
@@ -309,11 +309,13 @@ class KubernetesCollector:
 
         result = {
             "p95_startup_seconds": round(p95, 2),
+            "sample_count": len(startup_durations),
         }
 
         logger.info(
-            "Collected startup latency p95_startup_seconds=%.2f",
+            "Collected startup latency p95_startup_seconds=%.2f sample_count=%d",
             result["p95_startup_seconds"],
+            result["sample_count"],
         )
 
         return result

--- a/app/scoring/normalization.py
+++ b/app/scoring/normalization.py
@@ -123,9 +123,13 @@ def score_image_pull_health(
 #     }
 #     return score, reason, raw
 
-
-def score_startup_latency(*, p95_startup_seconds: float) -> tuple[float, str, dict]:
-    if p95_startup_seconds < 30:
+def score_startup_latency(
+    *, p95_startup_seconds: float, sample_count: int = 0
+) -> tuple[float, str, dict]:
+    if sample_count == 0:
+        score = 50.0
+        reason = "Pod startup latency is unavailable because no valid startup samples were found."
+    elif p95_startup_seconds < 30:
         score = 100.0
         reason = "Pod startup latency is healthy."
     elif p95_startup_seconds < 60:
@@ -140,8 +144,28 @@ def score_startup_latency(*, p95_startup_seconds: float) -> tuple[float, str, di
 
     raw = {
         "p95_startup_seconds": p95_startup_seconds,
+        "sample_count": sample_count,
     }
     return score, reason, raw
+
+# def score_startup_latency(*, p95_startup_seconds: float) -> tuple[float, str, dict]:
+#     if p95_startup_seconds < 30:
+#         score = 100.0
+#         reason = "Pod startup latency is healthy."
+#     elif p95_startup_seconds < 60:
+#         score = 70.0
+#         reason = "Pod startup latency is elevated but still within tolerable range."
+#     elif p95_startup_seconds < 120:
+#         score = 40.0
+#         reason = "Pod startup latency is high and may delay safe rollout."
+#     else:
+#         score = 10.0
+#         reason = "Pod startup latency is critically high."
+#
+#     raw = {
+#         "p95_startup_seconds": p95_startup_seconds,
+#     }
+#     return score, reason, raw
 
 
 def score_dependency_health(*, dns_ok: bool, registry_ok: bool) -> tuple[float, str, dict]:


### PR DESCRIPTION
## Summary

This PR handles empty startup latency samples conservatively.

After scoping startup latency to `deploy-confidence-service` pods, the collector could return `p95_startup_seconds=0.0` when no valid readiness-based startup samples were available yet. That caused startup latency to be scored as healthy even though no real startup sample existed.

This change adds sample awareness to startup latency collection and scoring so empty sample sets no longer produce a false healthy result.

## Why

A startup latency value of `0.0` should not automatically be interpreted as ideal startup behavior when the collector has no valid samples.

For deploy-confidence scoring, an empty sample set should be treated as unavailable or uncertain rather than healthy.

## Scope of change

This change is limited to:

- `app/collectors/kubernetes_collector.py`
- `app/scoring/normalization.py`

## What changed

### Collector
- added `sample_count` to the startup latency collector output
- preserved `p95_startup_seconds`
- updated logging to include the number of valid startup samples used

### Scoring
- updated `score_startup_latency()` to handle `sample_count == 0`
- empty startup sample sets now produce a conservative score instead of a false healthy result

## Impact

- prevents empty startup latency samples from being scored as healthy
- improves deploy-confidence signal quality during startup and rollout windows
- keeps the startup latency payload simple and reviewable
- does not require PostgreSQL schema changes
- does not change unrelated scoring components

## Out of scope

- startup latency threshold tuning
- node headroom fixes
- database schema changes
- broader scoring redesign
- making startup latency filtering configurable

## Validation

After deployment:
- verified the pod remains healthy
- verified `/live` and `/ready` continue to return 200
- verified startup latency logs now include `sample_count`
- verified `sample_count=0` no longer results in a healthy startup latency score
- verified dashboard behavior reflects unavailable startup samples more accurately

Closes #7 