### PR TITLE
feat: make dependency health targets configurable

### DIFF
--- a/app/collectors/dependency_checks.py
+++ b/app/collectors/dependency_checks.py
@@ -3,6 +3,8 @@ import socket
 
 import httpx
 
+from app.settings import settings
+
 logger = logging.getLogger(__name__)
 
 
@@ -13,14 +15,15 @@ class DependencyCheckError(Exception):
 class DependencyChecker:
     def __init__(
         self,
-        dns_target: str = "quay.io",
+        dns_target: str | None = None,
         registry_urls: list[str] | None = None,
         timeout: float = 5.0,
     ) -> None:
-        self.dns_target = dns_target
+        self.dns_target = dns_target or settings.dependency_dns_target
         self.registry_urls = registry_urls or [
-            "https://quay.io",
-            "https://public.ecr.aws",
+            url.strip()
+            for url in settings.dependency_registry_urls.split(",")
+            if url.strip()
         ]
         self.timeout = timeout
 
@@ -51,7 +54,9 @@ class DependencyChecker:
                 logger.warning("Registry reachability check failed for url=%s", url)
                 results.append(False)
             except Exception as exc:
-                raise DependencyCheckError(f"Unexpected registry check failure: {exc}") from exc
+                raise DependencyCheckError(
+                    f"Unexpected registry check failure: {exc}"
+                ) from exc
 
         return all(results) if results else False
 
@@ -71,3 +76,100 @@ class DependencyChecker:
         )
 
         return result
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# import logging
+# import socket
+#
+# import httpx
+#
+# logger = logging.getLogger(__name__)
+#
+#
+# class DependencyCheckError(Exception):
+#     """Raised when dependency checks fail unexpectedly."""
+#
+#
+# class DependencyChecker:
+#     def __init__(
+#         self,
+#         dns_target: str = "quay.io",
+#         registry_urls: list[str] | None = None,
+#         timeout: float = 5.0,
+#     ) -> None:
+#         self.dns_target = dns_target
+#         self.registry_urls = registry_urls or [
+#             "https://quay.io",
+#             "https://public.ecr.aws",
+#         ]
+#         self.timeout = timeout
+#
+#     def check_dns(self) -> bool:
+#         try:
+#             socket.getaddrinfo(self.dns_target, 443)
+#             logger.info("DNS check passed for target=%s", self.dns_target)
+#             return True
+#         except socket.gaierror:
+#             logger.warning("DNS check failed for target=%s", self.dns_target)
+#             return False
+#         except Exception as exc:
+#             raise DependencyCheckError(f"Unexpected DNS check failure: {exc}") from exc
+#
+#     def check_registry_reachability(self) -> bool:
+#         results: list[bool] = []
+#
+#         for url in self.registry_urls:
+#             try:
+#                 response = httpx.get(url, timeout=self.timeout, follow_redirects=True)
+#                 results.append(response.status_code < 500)
+#                 logger.info(
+#                     "Registry reachability check url=%s status_code=%s",
+#                     url,
+#                     response.status_code,
+#                 )
+#             except httpx.HTTPError:
+#                 logger.warning("Registry reachability check failed for url=%s", url)
+#                 results.append(False)
+#             except Exception as exc:
+#                 raise DependencyCheckError(f"Unexpected registry check failure: {exc}") from exc
+#
+#         return all(results) if results else False
+#
+#     def collect_dependency_health(self) -> dict[str, bool]:
+#         dns_ok = self.check_dns()
+#         registry_ok = self.check_registry_reachability()
+#
+#         result = {
+#             "dns_ok": dns_ok,
+#             "registry_ok": registry_ok,
+#         }
+#
+#         logger.info(
+#             "Collected dependency health dns_ok=%s registry_ok=%s",
+#             dns_ok,
+#             registry_ok,
+#         )
+#
+#         return result

--- a/app/config.py
+++ b/app/config.py
@@ -26,6 +26,9 @@ class Settings(BaseSettings):
 
     kubernetes_in_cluster: bool = False
 
+    dependency_dns_target: str = "quay.io"
+    dependency_registry_urls: str = "https://quay.io,https://public.ecr.aws"
+
     model_config = SettingsConfigDict(
         env_file=".env",
         env_file_encoding="utf-8",

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -19,3 +19,6 @@ data:
 
   KUBERNETES_IN_CLUSTER: "true"
 
+  DEPENDENCY_DNS_TARGET: "dependency-echo.deploy-confidence-tests.svc.cluster.local"
+  DEPENDENCY_REGISTRY_URLS: "http://dependency-echo.deploy-confidence-tests.svc.cluster.local"
+


### PR DESCRIPTION
## Summary

This PR makes dependency-health targets configurable and supports validation against a separate in-cluster test dependency.

## Change

- added configurable dependency DNS target
- added configurable dependency registry URL list
- removed reliance on hardcoded dependency defaults
- enables healthy / failure / recovery testing without editing Python code

## Why

The deploy-confidence service should validate dependency health against configurable targets so the signal can be tested safely and reused in different environments.

## Validation plan

- point dependency health to a dedicated in-cluster test service
- confirm healthy state
- scale test dependency to zero and confirm degraded state
- restore test dependency and confirm recovery